### PR TITLE
Lxc compatibility

### DIFF
--- a/OpenWrt/geoip-shell-lib-owrt.sh
+++ b/OpenWrt/geoip-shell-lib-owrt.sh
@@ -9,7 +9,7 @@
 
 checkutil () { command -v "$1" 1>/dev/null; }
 
-detect_fw_backend() {
+get_def_fw_backend() {
 	case "$_OWRTFW" in
 		3) printf ipt ;;
 		4) printf nft ;;

--- a/OpenWrt/geoip-shell-lib-owrt.sh
+++ b/OpenWrt/geoip-shell-lib-owrt.sh
@@ -9,15 +9,6 @@
 
 checkutil () { command -v "$1" 1>/dev/null; }
 
-get_def_fw_backend() {
-	case "$_OWRTFW" in
-		3) printf ipt ;;
-		4) printf nft ;;
-		*) echolog -err "Invalid OpenWrt firewall version '$_OWRTFW'."; return 1
-	esac
-	:
-}
-
 enable_owrt_persist() {
 	[ "$no_persist" = true ] && {
 		printf '%s\n\n' "Installed without persistence functionality."

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ _(Note that some commands require root privileges, so you will likely need to ru
 
     `curl -L "$(curl -s https://api.github.com/repos/friendly-bits/geoip-shell/releases | grep -m1 -o 'https://api.github.com/repos/friendly-bits/geoip-shell/tarball/[^"]*')" > geoip-shell.tar.gz`
   
-  - to extract, run: `tar -xvf geoip-shell.tar.gz`
+  - to extract, run: `tar -zxvf geoip-shell.tar.gz`
   </details>
 
 **3)** Extract all files included in the release into the same folder somewhere in your home directory and `cd` into that directory in your terminal.

--- a/check-ip-in-source.sh
+++ b/check-ip-in-source.sh
@@ -32,9 +32,6 @@ done
 
 . "$geoinit_path" || exit 1
 
-# set $cca2_path
-set_path cca2 cca2.list "$conf_dir"
-
 
 #### USAGE
 
@@ -66,7 +63,7 @@ EOF
 
 while getopts ":c:i:u:dh" opt; do
 	case $opt in
-	c) ccode=$OPTARG ;;
+	c) ccode_arg=$OPTARG ;;
 	i) ips=$OPTARG ;;
 	u) source_arg=$OPTARG ;;
 	d) debugmode_arg=1 ;;
@@ -111,7 +108,6 @@ default_source=ripe
 
 tolower source_arg
 dl_source="${source_arg:-"$default_source"}"
-toupper ccode
 ip_check_rv=0
 
 
@@ -119,13 +115,11 @@ ip_check_rv=0
 
 check_deps grepcidr || die
 
-[ -z "$ccode" ] && { usage; die "Specify country code with '-c <country_code>'."; }
-[ "$(printf %s "$ccode" | wc -w)" -gt 1 ] && { usage; die "Specify only one country code."; }
-
-validate_ccode "$ccode" "$cca2_path"; rv=$?
-case "$rv" in
-	1) die ;;
-	2) usage; die "Invalid country code: '$ccode'."
+normalize_ccode ccode "$ccode_arg"
+case $? in
+	0) ;;
+	2|3) usage; die "Invalid country code '$ccode_arg'. Specify one country code with '-c <country_code>'." ;;
+	*) die
 esac
 
 checkvars dl_source

--- a/geoip-shell-apply.sh
+++ b/geoip-shell-apply.sh
@@ -359,7 +359,7 @@ done
 # planned_ipsets_$direction - will be used to create direction-specific rules for iplists
 # planned_ipsets - all planned final ipsets
 # rm_ipsets - ipsets to remove
-# load_ipsets - ipsets to load from file
+# ipsets_to_load - ipsets to load from file
 
 getstatus "$status_file" || die "$FAIL read the status file '$status_file'."
 
@@ -367,7 +367,7 @@ curr_ipsets="$(get_ipsets)"
 
 nl2sp curr_ipsets_sp "$curr_ipsets"
 
-unset planned_ipsets rm1_ipsets load_ipsets
+unset planned_ipsets rm1_ipsets ipsets_to_load
 for direction in inbound outbound; do
 	eval "
 		${direction}_list_ids=\"\$${direction}_iplists\"
@@ -414,7 +414,7 @@ subtract_a_from_b "$planned_ipsets" "$curr_ipsets_sp" rm2_ipsets
 san_str rm_ipsets "$rm1_ipsets $rm2_ipsets"
 
 subtract_a_from_b "$rm_ipsets" "$curr_ipsets_sp" keep_ipsets
-subtract_a_from_b "$keep_ipsets" "$planned_ipsets" load_ipsets
+subtract_a_from_b "$keep_ipsets" "$planned_ipsets" ipsets_to_load
 
 
 debugprint "curr_ipsets_sp: '$curr_ipsets_sp'"
@@ -423,10 +423,10 @@ debugprint "rm1 ipsets: '$rm1_ipsets'"
 debugprint "rm2 ipsets: '$rm2_ipsets'"
 debugprint "rm ipsets: '$rm_ipsets'"
 debugprint "keep ipsets: '$keep_ipsets'"
-debugprint "load ipsets: '$load_ipsets'"
+debugprint "ipsets to load : '$ipsets_to_load'"
 
 # check that there are iplist files to load ipsets from
-for ipset in $load_ipsets; do
+for ipset in $ipsets_to_load; do
 	get_ipset_id "$ipset"
 	[ -f "$iplist_path" ] || die "Can not find file '$iplist_path' to load ipset '$ipset'."
 done

--- a/geoip-shell-apply.sh
+++ b/geoip-shell-apply.sh
@@ -370,9 +370,12 @@ nl2sp curr_ipsets_sp "$curr_ipsets"
 unset planned_ipsets rm1_ipsets ipsets_to_load
 for direction in inbound outbound; do
 	eval "
-		${direction}_list_ids=\"\$${direction}_iplists\"
-		list_ids=\"\$${direction}_list_ids\"
+		list_ids=\"\$${direction}_iplists\"
 		geomode=\"\$${direction}_geomode\""
+
+	separate_excl_iplists list_ids "$list_ids" || die
+
+	eval "${direction}_list_ids=\"$list_ids\""
 
 	debugprint "$direction list IDs: '$list_ids'"
 

--- a/geoip-shell-apply.sh
+++ b/geoip-shell-apply.sh
@@ -103,8 +103,9 @@ get_ipset_id() {
 	esac
 	case "$1" in
 		*local_*)
-			eval "iplist_path=\"\${${1}_file}\""
-			[ -s "$iplist_path" ] || { echolog -err "Can not find local iplist file '$iplist_path'."; return 1; } ;;
+			eval "iplist_path=\"\${${1#"${p_name}_"}_file}\""
+			[ -s "$iplist_path" ] || { echolog -err "Can not find local iplist file '$iplist_path'."; return 1; }
+			ipset_el_type="${iplist_path##*.}" ;;
 		*)
 			ipset_el_type=net
 			iplist_path="${iplist_dir}/${list_id}.iplist"
@@ -330,7 +331,7 @@ for family in ipv4 ipv6; do
 		filename="local_${local_type}_${family}"
 		ipset_prefix=
 		[ "$_fw_backend" = ipt ] && ipset_prefix="${geotag}_"
-		ipset_name="${ipset_prefix}local_${local_type}_${family#ipv}"
+		ipset_name="local_${local_type}_${family#ipv}"
 
 		iplist_found=
 		for dir in "$local_iplists_dir" "$staging_local_dir"; do
@@ -342,8 +343,8 @@ for family in ipv4 ipv6; do
 		done
 
 		[ "$iplist_found" ] || continue
-		add2list local_ipsets "$ipset_name"
-		add2list "local_${local_type}_ipsets" "$ipset_name"
+		add2list local_ipsets "${ipset_prefix}${ipset_name}"
+		add2list "local_${local_type}_ipsets" "${ipset_prefix}${ipset_name}"
 	done
 done
 

--- a/geoip-shell-backup.sh
+++ b/geoip-shell-backup.sh
@@ -134,23 +134,23 @@ cp_conf() {
 		*) echolog -err "cp_conf: bad argument '$1'"; return 1
 	esac
 
-	for bak_f in status config; do
-		eval "cp_src=\"$src_d\$${bak_f}_file$src_f\" \
-			cp_dest=\"$dest_d\$${bak_f}_file$dest_f\"
-			dest_compare_f=\"$compare_d\$${bak_f}_file$dest_f\""
+	for bak_obj in status config; do
+		eval "cp_src=\"$src_d\$${bak_obj}_file$src_f\" \
+			cp_dest=\"$dest_d\$${bak_obj}_file$dest_f\"
+			dest_compare_f=\"$compare_d\$${bak_obj}_file$dest_f\""
 		[ "$cp_src" ] && [ "$cp_dest" ] || { echolog -err "cp_conf: $FAIL set \$cp_src or \$cp_dest"; return 1; }
 		[ -f "$cp_src" ] || continue
 		[ -f "$dest_compare_f" ] && compare_files "$cp_src" "$dest_compare_f" && {
 			debugprint "$cp_src is identical to $dest_compare_f"
-			[ "$1" = backup ] && {
+			[ "$1" = backup ] && [ "$dest_compare_f" != "$cp_dest" ] && {
 				debugprint "Moving '$dest_compare_f' to '$cp_dest'"
-				mv "$dest_compare_f" "$cp_dest" || { echolog -err "$cp_act the $bak_f file failed."; return 1; }
+				mv "$dest_compare_f" "$cp_dest" || { echolog -err "$cp_act the $bak_obj file failed."; return 1; }
 			}
 			continue
 		}
 		debugprint "Copying '$cp_src' to '$cp_dest'"
-		printf %s "$cp_act the $bak_f file... "
-		cp "$cp_src" "$cp_dest" || { echolog -err "$cp_act the $bak_f file failed."; return 1; }
+		printf %s "$cp_act the $bak_obj file... "
+		cp "$cp_src" "$cp_dest" || { echolog -err "$cp_act the $bak_obj file failed."; return 1; }
 		OK
 	done
 }

--- a/geoip-shell-cronsetup.sh
+++ b/geoip-shell-cronsetup.sh
@@ -317,8 +317,8 @@ esac
 	case "$no_persist" in
 		false) create_cron_job persistence ;;
 		true) rm_cron_job persistence
-			echolog "${_nl}Note: no-persistence option was specified during installation. Geoip blocking will likely be deactivated upon reboot." \
-			"To enable persistence, install $p_name again without the '-n' option."
+			echolog "${_nl}Note: no-persistence option is set to 'true'. Geoblocking may be deactivated upon reboot." \
+			"To enable persistence, use the command \'$p_name configure -n false\'."
 	esac
 }
 

--- a/geoip-shell-fetch.sh
+++ b/geoip-shell-fetch.sh
@@ -632,8 +632,19 @@ done
 newifs "$_nl" cca
 set -- $cca2_list
 oldifs cca
-for i in 1 2 3 4 5; do
-	eval "c=\"\${$i}\""
+for c in "$@"; do
+	case "$c" in
+		'') continue ;;
+		*[!\ \	]*) ;;
+		*) continue
+	esac
+	case "$c" in
+		*[!\ =A-Za-z\	]*|*=*=*) die "Unexpected data in cca2.list" ;;
+		*=*)
+	esac
+	case "${c%%=*}" in
+		*[!a-zA-Z]*) die "Unexpected data in cca2.list"
+	esac
 	set_a_arr_el registry_ccodes_arr "$c"
 done
 

--- a/geoip-shell-fetch.sh
+++ b/geoip-shell-fetch.sh
@@ -440,7 +440,7 @@ fetch_maxmind() {
 		preparsed_db_mm="/tmp/${p_name}_preparsed-${family}.gz.tmp"
 		for ccode in $ccodes_need_update; do
 			list_id="${ccode}_${family}"
-			case "$exclude_iplists" in *"$list_id"*) continue; esac
+			case " $excl_file_lists " in *" $list_id "*) continue; esac
 			parsed_list_mm="/tmp/${p_name}_fetched-${list_id}.tmp"
 			printf %s "Parsing the IP list for '${purple}$list_id${n_c}'... "
 
@@ -462,10 +462,9 @@ process_ccode() {
 	curr_ccode="$1"
 	tolower curr_ccode_lc "$curr_ccode"
 	unset list_path fetched_file
-
 	for family in $families; do
 		list_id="${curr_ccode}_${family}"
-		case "$exclude_iplists" in *"$list_id"*) continue; esac
+		case " $excl_file_lists " in *" $list_id "*) continue; esac
 
 		rm_fetched_list_id=
 		case "$dl_src" in

--- a/geoip-shell-fetch.sh
+++ b/geoip-shell-fetch.sh
@@ -771,24 +771,9 @@ debugprint "http: '$http', ssl_ok: '$ssl_ok'"
 
 #### VARIABLES
 
-unset lists exclude_iplists excl_list_ids failed_lists fetched_lists
-[ -s "$excl_file" ] && nodie=1 getconfig exclude_iplists exclude_iplists "$excl_file"
+separate_excl_iplists san_lists "$lists_arg" || die
 
-for list_id in $lists_arg; do
-	case "$list_id" in
-		*_*) toupper cc_up "${list_id%%_*}"; tolower fml_lo "_${list_id#*_}" ;;
-		*) die "invalid list ID '$list_id'."
-	esac
-	list_id="$cc_up$fml_lo"
-	case "$exclude_iplists" in *"$list_id"*)
-		add2list excl_list_ids "$list_id"
-		continue
-	esac
-	add2list lists "$list_id"
-done
-san_lists="$lists"
-
-[ "$excl_list_ids" ] && report_excluded_lists "$excl_list_ids"
+unset failed_lists fetched_lists
 
 
 #### Checks

--- a/geoip-shell-fetch.sh
+++ b/geoip-shell-fetch.sh
@@ -791,8 +791,8 @@ group_lists_by_registry
 
 # check connectivity
 case "$dl_src" in
-	ripe) con_check_url="${ripe_url_api}v4_format=prefix&resource=nl" ;;
-	ipdeny) con_check_url="$ipdeny_ipv4_url" ;;
+	ripe) con_check_url="${ripe_url_api%%/*}" ;;
+	ipdeny) con_check_url="${ipdeny_ipv4_url%%/*}" ;;
 	maxmind)
 		checkvars maxmind_url mm_license_type mm_acc_id mm_license_key
 		con_check_url="${maxmind_url%%/*}"

--- a/geoip-shell-fetch.sh
+++ b/geoip-shell-fetch.sh
@@ -647,6 +647,8 @@ for c in "$@"; do
 	set_a_arr_el registry_ccodes_arr "$c"
 done
 
+load_exclusions
+
 #### Check for valid DL source
 default_source=ripe
 is_alphanum "$source_arg" && tolower source_arg && subtract_a_from_b "$valid_sources" "$source_arg" ||

--- a/geoip-shell-geoinit.sh
+++ b/geoip-shell-geoinit.sh
@@ -27,6 +27,6 @@ check_shell
 [ "$root_ok" ] || { [ "$(id -u)" = 0 ] && export root_ok=1; }
 . "${_lib}-common.sh" || exit 1
 
-[ "$root_ok" ] && [ ! "$inst_root_gs" ] && { _fw_backend="$(detect_fw_backend)" || die; }
+[ "$root_ok" ] && [ ! "$inst_root_gs" ] && { _fw_backend="$(get_def_fw_backend)" || die; }
 
 :

--- a/geoip-shell-geoinit.sh
+++ b/geoip-shell-geoinit.sh
@@ -27,6 +27,4 @@ check_shell
 [ "$root_ok" ] || { [ "$(id -u)" = 0 ] && export root_ok=1; }
 . "${_lib}-common.sh" || exit 1
 
-[ "$root_ok" ] && [ ! "$inst_root_gs" ] && { _fw_backend="$(get_def_fw_backend)" || die; }
-
 :

--- a/geoip-shell-install.sh
+++ b/geoip-shell-install.sh
@@ -466,7 +466,7 @@ if [ ! "\$_fw_backend" ]; then
 	[ "\$first_setup" ] && return 0
 	case "\$me \$1" in "\$p_name configure"|"\${p_name}-manage.sh configure"|*" -h"*|*" -V"*) return 0; esac
 	[ ! "\$in_uninstall" ] && die "Config file \$conf_file is missing or corrupted. Please run '\$p_name configure'."
-	_fw_backend="\$(detect_fw_backend)"
+	_fw_backend="\$(get_def_fw_backend)"
 elif ! check_fw_backend "\$_fw_backend"; then
 	_fw_be_rv=\$?
 	if [ "\$in_uninstall" ]; then

--- a/geoip-shell-install.sh
+++ b/geoip-shell-install.sh
@@ -381,6 +381,8 @@ check_files "$script_files $lib_files $script_dir/cca2.list $owrt_init $owrt_fw_
 	die "missing files: $missing_files."
 OK
 
+[ ! "$inst_root_gs" ] && { detect_fw_backends 1>/dev/null || die; }
+
 
 #### MAIN
 
@@ -466,7 +468,6 @@ if [ ! "\$_fw_backend" ]; then
 	[ "\$first_setup" ] && return 0
 	case "\$me \$1" in "\$p_name configure"|"\${p_name}-manage.sh configure"|*" -h"*|*" -V"*) return 0; esac
 	[ ! "\$in_uninstall" ] && die "Config file \$conf_file is missing or corrupted. Please run '\$p_name configure'."
-	_fw_backend="\$(get_def_fw_backend)"
 elif ! check_fw_backend "\$_fw_backend"; then
 	_fw_be_rv=\$?
 	if [ "\$in_uninstall" ]; then

--- a/geoip-shell-manage.sh
+++ b/geoip-shell-manage.sh
@@ -330,16 +330,13 @@ restore_from_config() {
 		prev_config_try=1
 		export main_config="$prev_config"
 
-		{ nodie=1 export_conf=1 get_config_vars || { echolog -err "$FAIL load the previous config."; false; }; } &&
-		_prev="previous " &&
-		{
+		if nodie=1 export_conf=1 get_config_vars && _prev="previous " &&
 			[ ! "$_fw_backend_change" ] ||
-			{
-				[ "$_fw_backend" ] && . "${_lib}-${_fw_backend}.sh" ||
-					{ echolog -err "$FAIL load the '$_fw_backend' library."; false; }
-			}
-		} &&
-		restore_from_config && { set_all_config; return 0; }
+				{ [ "$_fw_backend_change" ] && [ "$_fw_backend" ] && . "${_lib}-${_fw_backend}.sh"; }; then
+					restore_from_config && { set_all_config; return 0; }
+		else
+			echolog -err "$FAIL load the previous config."
+		fi
 	}
 
 	# recover from backup

--- a/geoip-shell-manage.sh
+++ b/geoip-shell-manage.sh
@@ -674,7 +674,21 @@ for direction in inbound outbound; do
 	done
 
 	# country codes
-	[ "$ccodes_arg" ] && { normalize_ccodes ccodes_arg "$ccodes_arg" || die; }
+	if [ -n "$ccodes_arg" ]; then
+		norm_ccodes='' bad_ccodes=''
+		toupper ccodes_arg
+		for ccode in $ccodes_arg; do
+			normalize_ccode norm_ccode "$ccode"
+			case $? in
+				1) die "Internal error while validating country codes." ;;
+				3) bad_ccodes="$bad_ccodes$ccode "
+			esac
+			norm_ccodes="${norm_ccodes}${norm_ccode} "
+		done
+		[ "$bad_ccodes" ] && die "Invalid 2-letters country codes: '${bad_ccodes% }'."
+		ccodes_arg="${norm_ccodes% }"
+	fi
+
 	if { [ "$ccodes_arg_unset" ] && [ "$iplists_unset" ]; } || [ "$ccodes_arg" ] || [ "$geomode_change" ]; then
 		if [ "$nointeract" ]; then
 			[ "$direction" = outbound ] && {

--- a/geoip-shell-manage.sh
+++ b/geoip-shell-manage.sh
@@ -498,8 +498,6 @@ done
 
 run_command="$i_script-run.sh"
 
-[ -f "$excl_file" ] && nodie=1 getconfig exclude_iplists exclude_iplists "$excl_file"
-
 
 ## Check args for sanity
 
@@ -676,7 +674,7 @@ for direction in inbound outbound; do
 	done
 
 	# country codes
-	[ "$ccodes_arg" ] && validate_ccodes "$ccodes_arg"
+	[ "$ccodes_arg" ] && { normalize_ccodes ccodes_arg "$ccodes_arg" || die; }
 	if { [ "$ccodes_arg_unset" ] && [ "$iplists_unset" ]; } || [ "$ccodes_arg" ] || [ "$geomode_change" ]; then
 		if [ "$nointeract" ]; then
 			[ "$direction" = outbound ] && {
@@ -695,17 +693,14 @@ for direction in inbound outbound; do
 		done
 
 	# generate a list of requested iplists
-	unset lists_req excl_list_ids
+	lists_req=
 	for ccode in $ccodes; do
 		for f in $families; do
-			list_id="${ccode}_$f"
-			case "$exclude_iplists" in *"$list_id"*)
-				add2list excl_list_ids "$list_id"
-				continue
-			esac
-			add2list lists_req "$list_id"
+			add2list lists_req "${ccode}_$f"
 		done
 	done
+
+	separate_excl_iplists lists_req "$lists_req" || die
 
 	eval "${direction}_lists_req"='$lists_req' \
 		"${direction}_ccodes"='$ccodes'

--- a/geoip-shell-manage.sh
+++ b/geoip-shell-manage.sh
@@ -402,6 +402,39 @@ set_first_setup() {
 	action=configure reset_req=1
 }
 
+report_lists() {
+	unset iplists_incoherent lists_reported local_lists_rl
+	for direction in inbound outbound; do
+		eval "geomode=\"\$${direction}_geomode\""
+		[ "$geomode" = disable ] && continue
+		get_active_iplists verified_lists "$direction"
+		nl2sp verified_lists
+		for list_id in $verified_lists; do
+			case "$list_id" in *local_*)
+				add2list local_lists_rl "$list_id"
+			esac
+		done
+		subtract_a_from_b "$local_lists_rl" "$verified_lists" ccode_lists
+		verified_lists_sp="$local_lists_rl"
+		[ "$ccode_lists" ] && verified_lists_sp="$verified_lists_sp $ccode_lists"
+		[ ! "$lists_reported" ] && printf '\n'
+		report_lists=
+		for list_id in $verified_lists_sp; do
+			case "$list_id" in
+				allow_in_*|allow_out_*|allow_*|dhcp_*) continue ;;
+				*) report_lists="$report_lists$list_id "
+			esac
+		done
+		if [ -n "$report_lists" ]; then
+			report_lists="'${blue}${report_lists% }${n_c}'"
+		else
+			report_lists="${red}None${n_c}"
+		fi
+		printf '%s\n' "Final IP lists in $direction $geomode: $report_lists."
+		lists_reported=1
+	done
+}
+
 
 #### showconfig
 [ "$action" = showconfig ] && { printf '\n%s\n\n' "Config in $conf_file:"; cat "$conf_file"; die 0; }

--- a/geoip-shell-manage.sh
+++ b/geoip-shell-manage.sh
@@ -461,8 +461,10 @@ unset conf_act rm_conf
 [ ! -s "$conf_file" ] || [ "$rm_conf" ] && {
 	rm -f "$conf_file"
 	rm_data
-	datadir=
-	local_iplists_dir=
+	for _conf_var in $ALL_CONF_VARS; do
+		is_alphanum "$_conf_var" || die "Internal error."
+		eval "$_conf_var="
+	done
 	rm_setupdone
 	export first_setup=1
 }

--- a/geoip-shell-run.sh
+++ b/geoip-shell-run.sh
@@ -115,6 +115,8 @@ san_str apply_lists_req "$lists_arg" || die
 			san_str apply_lists_req "$inbound_iplists $outbound_iplists" || die
 	esac
 
+separate_excl_iplists apply_lists_req "$apply_lists_req" || die
+
 fast_el_cnt "$apply_lists_req" " " lists_cnt
 
 failed_lists_cnt=0

--- a/geoip-shell-uninstall.sh
+++ b/geoip-shell-uninstall.sh
@@ -135,6 +135,7 @@ if [ "$_fw_backend" ] || detect_fw_backends; then
 				else
 					_fw_backend=nft
 				fi
+				# if not re-installing
 				[ ! "$keepdata" ] && echolog -warn "Based on heuristics, using firewall backend '${_fw_backend}ables' to remove existing geoblocking rules."
 		esac
 

--- a/iplist-exclusions.conf
+++ b/iplist-exclusions.conf
@@ -1,3 +1,3 @@
 # specified IP list IDs will be always ignored by the -manage and -fetch scripts
 # use with country codes which do not have any registered IP ranges for certain (or both) IP families
-exclude_iplists=AQ_ipv4 AQ_ipv6 KP_ipv6 MS_ipv6 HM_ipv4 HM_ipv6 BV_ipv4 BV_ipv6 SJ_ipv4 SJ_ipv6 SH_ipv4 SH_ipv6 UM_ipv4 UM_ipv6
+exclude_iplists=AQ_ipv4 AQ_ipv6 BV_ipv4 BV_ipv6 CC_ipv4 CC_ipv6 CF_ipv6 CX_ipv4 CX_ipv6 EH_ipv4 EH_ipv6 ER_ipv6 GS_ipv4 GS_ipv6 FK_ipv6 KP_ipv6 MS_ipv6 HM_ipv4 HM_ipv6 PN_ipv4 PN_ipv6 SJ_ipv4 SJ_ipv6 SH_ipv4 SH_ipv6 TF_ipv4 TF_ipv6 UM_ipv4 UM_ipv6 YT_ipv6

--- a/lib/geoip-shell-lib-common.sh
+++ b/lib/geoip-shell-lib-common.sh
@@ -291,7 +291,6 @@ call_script() {
 	[ "$use_lock" ] && rm_lock
 	$use_shell "$script_to_call" "$@"
 	call_rv=$?
-	unset main_config
 	debugexitmsg
 	[ "$use_lock" ] && mk_lock -f
 	use_lock=

--- a/lib/geoip-shell-lib-common.sh
+++ b/lib/geoip-shell-lib-common.sh
@@ -142,39 +142,6 @@ statustip() {
 	printf '\n%s\n\n' "View geoblocking status with '${blue}${p_name} status${n_c}' (may require 'sudo')."
 }
 
-report_lists() {
-	unset iplists_incoherent lists_reported local_lists_rl
-	for direction in inbound outbound; do
-		eval "geomode=\"\$${direction}_geomode\""
-		[ "$geomode" = disable ] && continue
-		get_active_iplists verified_lists "$direction"
-		nl2sp verified_lists
-		for list_id in $verified_lists; do
-			case "$list_id" in *local_*)
-				add2list local_lists_rl "$list_id"
-			esac
-		done
-		subtract_a_from_b "$local_lists_rl" "$verified_lists" ccode_lists
-		verified_lists_sp="$local_lists_rl"
-		[ "$ccode_lists" ] && verified_lists_sp="$verified_lists_sp $ccode_lists"
-		[ ! "$lists_reported" ] && printf '\n'
-		report_lists=
-		for list_id in $verified_lists_sp; do
-			case "$list_id" in
-				allow_in_*|allow_out_*|allow_*|dhcp_*) continue ;;
-				*) report_lists="$report_lists$list_id "
-			esac
-		done
-		if [ -n "$report_lists" ]; then
-			report_lists="'${blue}${report_lists% }${n_c}'"
-		else
-			report_lists="${red}None${n_c}"
-		fi
-		printf '%s\n' "Final IP lists in $direction $geomode: $report_lists."
-		lists_reported=1
-	done
-}
-
 unknownact() {
 	specifyact="Specify action in the 1st argument!"
 	case "$action" in

--- a/lib/geoip-shell-lib-common.sh
+++ b/lib/geoip-shell-lib-common.sh
@@ -158,21 +158,19 @@ report_lists() {
 		verified_lists_sp="$local_lists_rl"
 		[ "$ccode_lists" ] && verified_lists_sp="$verified_lists_sp $ccode_lists"
 		[ ! "$lists_reported" ] && printf '\n'
-		printf %s "Final IP lists in $direction $geomode: '${blue}"
-		if printf %s "$verified_lists_sp" |
-			sed "s/allow_in_${notblank}*//g;
-				s/allow_out_${notblank}*//g;
-				s/dhcp_${notblank}*//g;
-				s/^${blanks}//;
-				s/${blanks}$//;
-				s/${blanks}/ /g;
-				/^$/d" | grep . | tr -d '\n'
-		then
-			printf '%s\n' "${n_c}'."
+		report_lists=
+		for list_id in $verified_lists_sp; do
+			case "$list_id" in
+				allow_in_*|allow_out_*|allow_*|dhcp_*) continue ;;
+				*) report_lists="$report_lists$list_id "
+			esac
+		done
+		if [ -n "$report_lists" ]; then
+			report_lists="'${blue}${report_lists% }${n_c}'"
 		else
-			printf '%s\n' "${red}None${n_c}"
+			report_lists="${red}None${n_c}"
 		fi
-
+		printf '%s\n' "Final IP lists in $direction $geomode: $report_lists."
 		lists_reported=1
 	done
 }

--- a/lib/geoip-shell-lib-common.sh
+++ b/lib/geoip-shell-lib-common.sh
@@ -895,8 +895,7 @@ get_active_iplists() {
 	nl2sp ipset_iplists_sp "$ipset_iplists"
 	nl2sp fwrules_iplists_sp "$fwrules_iplists"
 
-	[ -n "$excl_file_lists" ] ||
-		{ [ -s "$excl_file" ] && nodie=1 getconfig excl_file_lists exclude_iplists "$excl_file" && export excl_file_lists; }
+	load_exclusions
 
 	inc=0
 	subtract_a_from_b "$ipset_iplists_sp" "$exp_iplists_gai" missing_ipsets ||
@@ -999,10 +998,16 @@ report_incoherence() {
 	done
 }
 
+load_exclusions() {
+	[ -n "$excl_file_lists" ] && return 0
+	[ -s "$excl_file" ] &&
+		nodie=1 getconfig excl_file_lists exclude_iplists "$excl_file" &&
+			export excl_file_lists
+}
+
 separate_excl_iplists() {
 	unset _excl_lists _ok_lists
-	[ -n "$excl_file_lists" ] ||
-		{ [ -s "$excl_file" ] && nodie=1 getconfig excl_file_lists exclude_iplists "$excl_file" && export excl_file_lists;  }
+	load_exclusions
 
 	for _list_id in $2; do
 		case "$_list_id" in

--- a/lib/geoip-shell-lib-ipt.sh
+++ b/lib/geoip-shell-lib-ipt.sh
@@ -125,11 +125,12 @@ rm_all_georules() {
 	done
 
 	# remove ipsets
-	rm_ipsets_rv=0
+	rm_ipsets_rv=1
 	unisleep
 	printf_s "Destroying $p_name ipsets... "
 	for ipset in $(ipset list -n | grep "$geotag"); do
-		ipset destroy "$ipset" || rm_ipsets_rv=1
+		ipset destroy "$ipset" || { rm_ipsets_rv=1; continue; }
+		rm_ipsets_rv=0
 	done
 	[ "$rm_ipsets_rv" = 0 ] && OK || FAIL
 	return "$rm_ipsets_rv"
@@ -529,7 +530,7 @@ apply_rules() {
 	### register load ipsets
 	ipsets_to_add=
 	for family in $families; do
-		for ipset in $load_ipsets; do
+		for ipset in $ipsets_to_load; do
 			[ ! "$ipset" ] && continue
 			get_ipset_id "$ipset" || die
 			case "$list_id" in *_*) ;; *) die "Invalid iplist ID '$list_id'."; esac

--- a/lib/geoip-shell-lib-ipt.sh
+++ b/lib/geoip-shell-lib-ipt.sh
@@ -516,6 +516,7 @@ apply_rules() {
 	#### Remove unneeded ipsets
 	[ -n "$rm_ipsets" ] && {
 		printf_s "Removing unneeded ipsets... "
+		unisleep
 		rm_ipsets_rv=0
 		for ipset in $rm_ipsets; do
 			rm_ipset "$ipset" "$curr_ipsets" || rm_ipsets_rv=1
@@ -523,7 +524,6 @@ apply_rules() {
 		done
 		[ "$rm_ipsets_rv" = 0 ] || { FAIL; echo; die; }
 		OK
-		echo
 	}
 
 	### register load ipsets

--- a/lib/geoip-shell-lib-ipt.sh
+++ b/lib/geoip-shell-lib-ipt.sh
@@ -125,12 +125,11 @@ rm_all_georules() {
 	done
 
 	# remove ipsets
-	rm_ipsets_rv=1
+	rm_ipsets_rv=0
 	unisleep
 	printf_s "Destroying $p_name ipsets... "
 	for ipset in $(ipset list -n | grep "$geotag"); do
 		ipset destroy "$ipset" || { rm_ipsets_rv=1; continue; }
-		rm_ipsets_rv=0
 	done
 	[ "$rm_ipsets_rv" = 0 ] && OK || FAIL
 	return "$rm_ipsets_rv"

--- a/lib/geoip-shell-lib-ipt.sh
+++ b/lib/geoip-shell-lib-ipt.sh
@@ -258,7 +258,7 @@ load_ipsets() {
 # 4 - path to file
 # 5 - curr ipsets
 reg_ipset() {
-	debugprint "Registering load ipset '$1'... "
+	debugprint "Registering load ipset '$1': type '$2', family '$3', path '$4' "
 	case "$5" in *"$1"*) echolog -err "reg_ipset: ipset '$1' already exists."; return 1; esac
 
 	[ -s "$4" ] || {

--- a/lib/geoip-shell-lib-nft.sh
+++ b/lib/geoip-shell-lib-nft.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# shellcheck disable=SC2154,SC2155,SC2015
+# shellcheck disable=SC2154,SC2155,SC2015,SC2034
 
 # geoip-shell-lib-ipt.sh
 

--- a/lib/geoip-shell-lib-nft.sh
+++ b/lib/geoip-shell-lib-nft.sh
@@ -207,7 +207,7 @@ report_fw_state() {
 
 destroy_tmp_ipsets() {
 	echo "Destroying temporary ipsets..."
-	for load_ipset in $load_ipsets; do
+	for load_ipset in $ipsets_to_load; do
 		nft delete set inet "$geotable" "$load_ipset" 1>/dev/null 2>/dev/null
 	done
 }
@@ -301,7 +301,7 @@ apply_rules() {
 
 	### load ipsets
 	printf_s "${_nl}Loading IP lists... "
-	for load_ipset in $load_ipsets; do
+	for load_ipset in $ipsets_to_load; do
 		get_ipset_id "$load_ipset" || die_a
 		[ -f "$iplist_path" ] || { FAIL; die_a "Can not find the iplist file '$iplist_path'."; }
 
@@ -315,7 +315,7 @@ apply_rules() {
 
 		rm -f "$iplist_path"
 
-		[ "$debugmode" ] && debugprint "elements in $load_ipset: $(sp2nl ipsets "$load_ipsets"; cnt_ipset_elements "$load_ipset" "$ipsets")"
+		[ "$debugmode" ] && debugprint "elements in $load_ipset: $(sp2nl ipsets "$ipsets_to_load"; cnt_ipset_elements "$load_ipset" "$ipsets")"
 	done
 	OK
 

--- a/lib/geoip-shell-lib-nft.sh
+++ b/lib/geoip-shell-lib-nft.sh
@@ -520,7 +520,7 @@ apply_rules() {
 	nft_output="$(printf '%s\n' "$nft_cmd_chain" | nft -f - 2>&1)" || {
 		FAIL
 		echolog -err "$FAIL apply new firewall rules"
-		echolog "nftables errors: '$(printf %s "$nft_output" | sed "s/${blank}*\^\^\^[\^]*${blank}*/ /g" | tr '\n' ' ' | head -c 1k)'"
+		echolog "nftables errors:${_nl}$(printf %s "$nft_output" | head -c 1k)"
 		die
 	}
 

--- a/lib/geoip-shell-lib-non-owrt.sh
+++ b/lib/geoip-shell-lib-non-owrt.sh
@@ -63,7 +63,7 @@ check_shell() {
 	export curr_sh_g
 }
 
-detect_fw_backend() {
+get_def_fw_backend() {
 	[ ! "$_fw_backend_arg" ] && {
 		if check_fw_backend nft 2>/dev/null; then
 			printf nft

--- a/lib/geoip-shell-lib-non-owrt.sh
+++ b/lib/geoip-shell-lib-non-owrt.sh
@@ -63,23 +63,6 @@ check_shell() {
 	export curr_sh_g
 }
 
-get_def_fw_backend() {
-	[ ! "$_fw_backend_arg" ] && {
-		if check_fw_backend nft 2>/dev/null; then
-			printf nft
-		else
-			check_fw_backend ipt 2>/dev/null
-			case $? in
-				0) printf ipt ;;
-				1) return 1 ;;
-				2) echolog -err "Neither nftables nor iptables not found."; return 1 ;;
-				3) echolog -err "Found iptables but utility 'ipset' not found."; return 1
-			esac
-		fi
-	}
-	:
-}
-
 # returns 0 if crontab is readable and cron or crond process is running, 1 otherwise
 # sets $cron_reboot if above conditions are satisfied and cron is not implemented via the busybox binary
 check_cron() {

--- a/lib/geoip-shell-lib-setup.sh
+++ b/lib/geoip-shell-lib-setup.sh
@@ -750,7 +750,7 @@ get_general_prefs() {
 		{
 			for el_type in net ip; do
 				if [ -f "$perm_file.$el_type" ] && compare_files "$perm_file.$el_type" "$staging_file"; then
-					echolog "${_nl}All IP's in file '$file' have already previously imported."
+					echolog "${_nl}All IP's in file '$file' have been previously imported."
 					set +f
 					rm -f "$staging_file"*
 					set -f

--- a/lib/geoip-shell-lib-setup.sh
+++ b/lib/geoip-shell-lib-setup.sh
@@ -455,7 +455,7 @@ warn_lockout() {
 
 # assigns default values, unless the var is set
 set_defaults() {
-	_fw_backend_def="$(detect_fw_backend)" || die
+	_fw_backend_def="$(get_def_fw_backend)" || die
 
 	# check RAM capacity, set default optimization policy for nftables sets to performance if RAM>=1840MiB
 	[ ! "$nft_perf" ] && {

--- a/lib/geoip-shell-lib-status.sh
+++ b/lib/geoip-shell-lib-status.sh
@@ -279,6 +279,7 @@ for direction in inbound outbound; do
 	report_fw_state "$direction"
 
 	[ "$verb_status" ] && {
+		load_exclusions
 		printf %s "  IP ranges count in active $direction geoblocking sets: "
 		case "$active_ccodes" in
 			'') printf '%s\n' "${red}None $_X"; incr_issues ;;
@@ -293,7 +294,7 @@ for direction in inbound outbound; do
 						list_empty=
 						eval "el_cnt=\"\${${list_id}_el_cnt}\""
 						[ "$el_cnt" = 0 ] && {
-							if is_included "$list_id" "$exclude_iplists"; then
+							if is_included "$list_id" "$excl_file_lists"; then
 								list_empty=" (excluded)"
 							else
 								list_empty=" $_X"

--- a/lib/geoip-shell-lib-status.sh
+++ b/lib/geoip-shell-lib-status.sh
@@ -44,7 +44,7 @@ incr_issues() { issues=$((issues+1)); }
 _Q="${red}?${n_c}"
 issues=0
 
-printf '\n%s\n\n%s\n' "${purple}$p_name status:${n_c}" "$p_name ${blue}v$curr_ver$n_c"
+printf '\n%s\n' "${purple}$p_name v$curr_ver status:${n_c}"
 
 case "$_fw_backend" in
 	ipt|nft) _fw="$blue${_fw_backend}ables$n_c" ;;

--- a/lib/geoip-shell-lib-uninstall.sh
+++ b/lib/geoip-shell-lib-uninstall.sh
@@ -167,6 +167,7 @@ rm_all_data() {
 }
 
 rm_data() {
+	[ -n "$datadir" ] || return 0
 	rm_geodir "$datadir"/backup backup
 	rm -f "$datadir"/status "$datadir"/ips_cnt
 	rm_dir_if_empty "$datadir"


### PR DESCRIPTION
- Prompt user to select the firewall backend when both iptables and nftables are available
- Detect running inside LXC containers, warn when running in unprivileged container and backend is nftables
- Use domain URLs (rather than download URLs) for connectivity check
- Sleep before removing ipsets with iptables (fixes iptables error)
- Implement generic exclusions check, ignore excluded list ID's in -run, -manage, -apply, -fetch
- Fix bugs with loading local iplists
- Many various logic improvements